### PR TITLE
Add 'GradientBg' widget

### DIFF
--- a/demo/src/window/gradient_bg/gradient_bg.blp
+++ b/demo/src/window/gradient_bg/gradient_bg.blp
@@ -1,0 +1,29 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $OriDemoGradientBgPage: Adw.Bin {
+    child: Box {
+        orientation: vertical;
+        vexpand: true;
+
+        Adw.PreferencesPage {
+            Adw.PreferencesGroup {
+                title: "Gradient Background";
+
+                header-suffix: Button animate {
+                    label: "Animate";
+                    clicked => $animate(template);
+                };
+
+                $OriGradientBg gradient_bg {
+                    styles [
+                        "card"
+                    ]
+
+                    overflow: hidden;
+                    vexpand: true;
+                }
+            }
+        }
+    };
+}

--- a/demo/src/window/gradient_bg/gradient_bg.blp
+++ b/demo/src/window/gradient_bg/gradient_bg.blp
@@ -2,28 +2,37 @@ using Gtk 4.0;
 using Adw 1;
 
 template $OriDemoGradientBgPage: Adw.Bin {
-    child: Box {
-        orientation: vertical;
-        vexpand: true;
+    DropTarget drop_target {
+        actions: copy;
+        formats: "GdkFileList";
+    }
 
-        Adw.PreferencesPage {
-            Adw.PreferencesGroup {
-                title: "Gradient Background";
+    child: Gtk.Overlay {
+        [overlay]
+        Box {
+            orientation: vertical;
+            valign: center;
+            spacing: 16;
 
-                header-suffix: Button animate {
-                    label: "Animate";
-                    clicked => $animate(template);
-                };
+            Button animate {
+                styles [
+                    "suggested-action",
+                    "circular"
+                ]
 
-                $OriGradientBg gradient_bg {
-                    styles [
-                        "card"
-                    ]
-
-                    overflow: hidden;
-                    vexpand: true;
-                }
+                icon-name: "media-playback-start-symbolic";
+                clicked => $animate(template);
+                valign: center;
+                halign: center;
             }
+
+            Label {
+                label: "Drag your single color svg pattern here";
+            }
+        }
+
+        $OriGradientBg gradient_bg {
+            vexpand: true;
         }
     };
 }

--- a/demo/src/window/gradient_bg/mod.rs
+++ b/demo/src/window/gradient_bg/mod.rs
@@ -79,23 +79,10 @@ glib::wrapper! {
         @extends adw::Bin, gtk::Widget;
 }
 
-fn hard_coded_theme_colors(dark: bool) -> Vec<gtk::graphene::Vec3> {
-    let colors = if dark {
-        vec![0xd6932e, 0xbc40db, 0x4280d7, 0x614ed5]
+fn hard_coded_theme_colors(dark: bool) -> &'static [i32] {
+    if dark {
+        &[0xd6932e, 0xbc40db, 0x4280d7, 0x614ed5]
     } else {
-        vec![0x94dae9, 0x9aeddb, 0x94c3f6, 0xac96f7]
-    };
-
-    let colors = colors
-        .into_iter()
-        .map(|int_color| {
-            let r = (int_color >> 16) & 0xFF;
-            let g = (int_color >> 8) & 0xFF;
-            let b = int_color & 0xFF;
-
-            gtk::graphene::Vec3::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
-        })
-        .collect();
-
-    colors
+        &[0x94dae9, 0x9aeddb, 0x94c3f6, 0xac96f7]
+    }
 }

--- a/demo/src/window/gradient_bg/mod.rs
+++ b/demo/src/window/gradient_bg/mod.rs
@@ -1,15 +1,17 @@
-use adw::prelude::*;
 use adw::subclass::prelude::*;
-use glib::clone;
 use gtk::gdk;
 use gtk::glib;
 
 mod imp {
+    use gtk::glib::clone;
+
     use super::*;
 
     #[derive(Debug, Default, gtk::CompositeTemplate)]
     #[template(file = "src/window/gradient_bg/gradient_bg.blp")]
     pub struct GradientBgPage {
+        #[template_child]
+        pub(super) drop_target: TemplateChild<gtk::DropTarget>,
         #[template_child]
         pub(super) gradient_bg: TemplateChild<ori::GradientBg>,
     }
@@ -33,6 +35,30 @@ mod imp {
     impl ObjectImpl for GradientBgPage {
         fn constructed(&self) {
             self.parent_constructed();
+
+            let gradient_bg = self.gradient_bg.to_owned();
+
+            let style_manager = adw::StyleManager::default();
+            gradient_bg.set_dark(style_manager.is_dark());
+            gradient_bg.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()));
+
+            style_manager.connect_dark_notify(clone!(@weak gradient_bg => move |style_manager| {
+                gradient_bg.set_dark(style_manager.is_dark());
+                gradient_bg.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()))
+            }));
+
+            self.drop_target.connect_drop(
+                clone!(@weak gradient_bg => @default-return false, move
+                    |_, value, _, _ | {
+                        let Ok(file_list) = value.get::<gdk::FileList>() else { return false; };
+
+                        let pattern_texture = file_list.files().iter().filter_map(|file| gdk::Texture::from_file(file).ok()).next();
+                        
+                        gradient_bg.set_pattern(pattern_texture);
+                        true
+                    }
+                ),
+            );
         }
     }
 
@@ -51,4 +77,25 @@ mod imp {
 glib::wrapper! {
     pub struct GradientBgPage(ObjectSubclass<imp::GradientBgPage>)
         @extends adw::Bin, gtk::Widget;
+}
+
+fn hard_coded_theme_colors(dark: bool) -> Vec<gtk::graphene::Vec3> {
+    let colors = if dark {
+        vec![0xd6932e, 0xbc40db, 0x4280d7, 0x614ed5]
+    } else {
+        vec![0x94dae9, 0x9aeddb, 0x94c3f6, 0xac96f7]
+    };
+
+    let colors = colors
+        .into_iter()
+        .map(|int_color| {
+            let r = (int_color >> 16) & 0xFF;
+            let g = (int_color >> 8) & 0xFF;
+            let b = int_color & 0xFF;
+
+            gtk::graphene::Vec3::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+        })
+        .collect();
+
+    colors
 }

--- a/demo/src/window/gradient_bg/mod.rs
+++ b/demo/src/window/gradient_bg/mod.rs
@@ -1,0 +1,54 @@
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use glib::clone;
+use gtk::gdk;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk::CompositeTemplate)]
+    #[template(file = "src/window/gradient_bg/gradient_bg.blp")]
+    pub struct GradientBgPage {
+        #[template_child]
+        pub(super) gradient_bg: TemplateChild<ori::GradientBg>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for GradientBgPage {
+        const NAME: &'static str = "OriDemoGradientBgPage";
+        type Type = super::GradientBgPage;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.bind_template_callbacks();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for GradientBgPage {
+        fn constructed(&self) {
+            self.parent_constructed();
+        }
+    }
+
+    impl WidgetImpl for GradientBgPage {}
+    impl BinImpl for GradientBgPage {}
+
+    #[gtk::template_callbacks]
+    impl GradientBgPage {
+        #[template_callback]
+        fn animate(&self) {
+            self.gradient_bg.animate();
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct GradientBgPage(ObjectSubclass<imp::GradientBgPage>)
+        @extends adw::Bin, gtk::Widget;
+}

--- a/demo/src/window/mod.rs
+++ b/demo/src/window/mod.rs
@@ -1,3 +1,4 @@
+mod gradient_bg;
 mod loading_indicator;
 mod shimmer_effect;
 mod spoiler;
@@ -27,8 +28,9 @@ mod imp {
             loading_indicator::LoadingIndicatorPage::static_type();
             shimmer_effect::ShimmerEffectPage::static_type();
             spoiler::SpoilerPage::static_type();
+            gradient_bg::GradientBgPage::static_type();
 
-            klass.bind_template();
+            klass.bind_template()
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/demo/src/window/window.blp
+++ b/demo/src/window/window.blp
@@ -1,9 +1,8 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $SpoilerWindow : Adw.ApplicationWindow {
+template $SpoilerWindow: Adw.ApplicationWindow {
     height-request: 400;
-
     default-height: 580;
     default-width: 840;
 
@@ -27,7 +26,6 @@ template $SpoilerWindow : Adw.ApplicationWindow {
             StackSidebar {
                 vexpand: true;
                 width-request: 270;
-
                 stack: stack;
             }
         }
@@ -56,7 +54,6 @@ template $SpoilerWindow : Adw.ApplicationWindow {
 
                     child: Adw.StatusPage {
                         vexpand: true;
-
                         title: "Welcome to Origami Demo";
                     };
                 }
@@ -80,6 +77,13 @@ template $SpoilerWindow : Adw.ApplicationWindow {
                     title: "Shimmer Effect";
 
                     child: $OriDemoShimmerEffectPage {};
+                }
+
+                StackPage {
+                    name: "gradient_bg";
+                    title: "Gradient Background";
+
+                    child: $OriDemoGradientBgPage {};
                 }
             }
         }

--- a/origami/src/gradient_bg/mod.rs
+++ b/origami/src/gradient_bg/mod.rs
@@ -1,0 +1,370 @@
+use std::cell::Cell;
+use std::cell::OnceCell;
+use std::cell::RefCell;
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use glib::clone;
+use gtk::gdk;
+use gtk::gio;
+use gtk::glib;
+use gtk::graphene;
+use gtk::gsk;
+
+const GRADIENT_SHADER: &[u8] = r#"
+// That shader was taken from Telegram for android source
+// https://github.com/DrKLO/Telegram/commit/2112affb2e4941334f8fbc3944385806b3c4e3d6#diff-dfdd1e8c4691747fd30199b7a2f5041a126b23e1450b29afe441eb0ebed01c68
+
+precision highp float;
+
+uniform vec3 color1;
+uniform vec3 color2;
+uniform vec3 color3;
+uniform vec3 color4;
+uniform vec2 p1;
+uniform vec2 p2;
+uniform vec2 p3;
+uniform vec2 p4;
+
+void mainImage(out vec4 fragColor,
+               in vec2 fragCoord,
+               in vec2 resolution,
+               in vec2 uv) {
+    uv.y = 1.0 - uv.y;
+
+    float dp1 = distance(uv, p1);
+    float dp2 = distance(uv, p2);
+    float dp3 = distance(uv, p3);
+    float dp4 = distance(uv, p4);
+    float minD = min(dp1, min(dp2, min(dp3, dp4)));
+    float p = 5.0;
+    dp1 = pow(1.0 - (dp1 - minD), p);
+    dp2 = pow(1.0 - (dp2 - minD), p);
+    dp3 = pow(1.0 - (dp3 - minD), p);
+    dp4 = pow(1.0 - (dp4 - minD), p);
+    float sumDp = dp1 + dp2 + dp3 + dp4;
+
+    vec3 color = (color1 * dp1 + color2 * dp2 + color3 * dp3 + color4 * dp4) / sumDp;
+    fragColor = vec4(color, 1.0);
+}
+"#
+.as_bytes();
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct GradientBg {
+        pub(super) gradient_texture: RefCell<Option<gdk::Texture>>,
+        pub(super) last_size: Cell<(f32, f32)>,
+
+        pub(super) shader: RefCell<Option<gsk::GLShader>>,
+        pub(super) pattern: RefCell<Option<gdk::Texture>>,
+
+        pub(super) animation: OnceCell<adw::Animation>,
+        pub(super) progress: Cell<f32>,
+        pub(super) phase: Cell<u32>,
+
+        pub(super) dark: Cell<bool>,
+
+        pub(super) colors: RefCell<Vec<graphene::Vec3>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for GradientBg {
+        const NAME: &'static str = "OriGradientBg";
+        type Type = super::GradientBg;
+        type ParentType = adw::Bin;
+    }
+
+    impl ObjectImpl for GradientBg {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            let obj = self.obj();
+
+            let style_manager = adw::StyleManager::default();
+            obj.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()));
+
+            style_manager.connect_dark_notify(clone!(@weak obj => move |style_manager| {
+                obj.imp().dark.set(style_manager.is_dark());
+                obj.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()))
+            }));
+
+            if style_manager.is_high_contrast() {
+                obj.add_css_class("fallback");
+            }
+
+            style_manager.connect_high_contrast_notify(clone!(@weak obj => move |style_manager| {
+                if style_manager.is_high_contrast() {
+                    obj.add_css_class("fallback");
+                } else if obj.imp().shader.borrow().is_some() {
+                    obj.remove_css_class("fallback");
+                }
+            }));
+
+            let target = adw::CallbackAnimationTarget::new(clone!(@weak obj => move |progress| {
+                let imp = obj.imp();
+                imp.gradient_texture.take();
+                let progress = progress as f32;
+                if progress >= 1.0 {
+                    imp.progress.set(0.0);
+                    imp.phase.set((imp.phase.get() + 1) % 8);
+                } else {
+                    imp.progress.set(progress)
+                }
+                obj.queue_draw();
+            }));
+
+            let animation = adw::TimedAnimation::builder()
+                .widget(&*obj)
+                .value_from(0.0)
+                .value_to(1.0)
+                .duration(200)
+                .target(&target)
+                .easing(adw::Easing::EaseInOutQuad)
+                .build()
+                .upcast();
+
+            self.animation.set(animation).unwrap();
+        }
+    }
+
+    impl WidgetImpl for GradientBg {
+        fn realize(&self) {
+            self.parent_realize();
+            self.obj().ensure_shader();
+        }
+
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            let widget = self.obj();
+
+            if widget.has_css_class("fallback") {
+                // fallback code
+                if let Some(child) = widget.child() {
+                    widget.snapshot_child(&child, snapshot);
+                }
+                return;
+            };
+
+            let width = widget.width() as f32;
+            let height = widget.height() as f32;
+
+            if width == 0.0 || height == 0.0 {
+                return;
+            }
+
+            let bounds = graphene::Rect::new(0.0, 0.0, width, height);
+
+            let size_changed = self.last_size.replace((width, height)) != (width, height);
+
+            self.snapshot_gradient(snapshot, &bounds, size_changed);
+
+            self.snapshot_pattern(snapshot, &bounds);
+        }
+    }
+
+    impl BinImpl for GradientBg {}
+
+    impl GradientBg {
+        fn snapshot_gradient(
+            &self,
+            snapshot: &gtk::Snapshot,
+            bounds: &graphene::Rect,
+            size_changed: bool,
+        ) {
+            if self.progress.get() == 0.0 {
+                let texture = match self.gradient_texture.take() {
+                    Some(texture) if !size_changed => texture,
+                    _ => {
+                        let renderer = self.obj().native().unwrap().renderer().unwrap();
+                        renderer.render_texture(self.gradient_shader_node(bounds), Some(bounds))
+                    }
+                };
+
+                snapshot.append_texture(&texture, bounds);
+                self.gradient_texture.replace(Some(texture));
+            } else {
+                snapshot.append_node(self.gradient_shader_node(bounds));
+            }
+        }
+
+        fn snapshot_pattern(&self, snapshot: &gtk::Snapshot, bounds: &graphene::Rect) {
+            let widget = self.obj();
+            let Some(pattern) = &*self.pattern.borrow() else {
+                // Nothing to snapshot
+                return;
+            };
+
+            let pattern_bounds = graphene::Rect::new(
+                0.0,
+                0.0,
+                pattern.width() as f32 * 0.3,
+                pattern.height() as f32 * 0.3,
+            );
+
+            let mut matrix = [0.0; 16];
+            let mut offset = [0.0; 4];
+            if self.dark.get() {
+                matrix[15] = -0.3;
+                offset = [0.08; 4];
+                offset[3] = 1.0;
+            } else {
+                matrix[15] = 0.1;
+            }
+            let color_matrix = graphene::Matrix::from_float(matrix);
+            let color_offset = graphene::Vec4::from_float(offset);
+
+            snapshot.push_color_matrix(&color_matrix, &color_offset);
+            snapshot.push_repeat(bounds, Some(&pattern_bounds));
+            snapshot.append_texture(pattern, &pattern_bounds);
+            snapshot.pop();
+            snapshot.pop();
+
+            if let Some(child) = widget.child() {
+                widget.snapshot_child(&child, snapshot);
+            }
+        }
+
+        fn gradient_shader_node(&self, bounds: &graphene::Rect) -> gsk::GLShaderNode {
+            let Some(gradient_shader) = &*self.shader.borrow() else {
+                unreachable!()
+            };
+
+            let args_builder = gsk::ShaderArgsBuilder::new(gradient_shader, None);
+
+            let progress = self.progress.get();
+            let phase = self.phase.get() as usize;
+
+            let colors = self.colors.borrow();
+
+            let &[c1, c2, c3, c4] = &colors[..] else {
+                unimplemented!("Unexpected color count");
+            };
+
+            args_builder.set_vec3(0, &c1);
+            args_builder.set_vec3(1, &c2);
+            args_builder.set_vec3(2, &c3);
+            args_builder.set_vec3(3, &c4);
+
+            let [p1, p2, p3, p4] = Self::calculate_positions(progress, phase);
+            args_builder.set_vec2(4, &p1);
+            args_builder.set_vec2(5, &p2);
+            args_builder.set_vec2(6, &p3);
+            args_builder.set_vec2(7, &p4);
+
+            gsk::GLShaderNode::new(gradient_shader, bounds, &args_builder.to_args(), &[])
+        }
+
+        fn calculate_positions(progress: f32, phase: usize) -> [graphene::Vec2; 4] {
+            static POSITIONS: [(f32, f32); 8] = [
+                (0.80, 0.10),
+                (0.60, 0.20),
+                (0.35, 0.25),
+                (0.25, 0.60),
+                (0.20, 0.90),
+                (0.40, 0.80),
+                (0.65, 0.75),
+                (0.75, 0.40),
+            ];
+
+            let mut points = [graphene::Vec2::new(0.0, 0.0); 4];
+
+            for i in 0..4 {
+                let start = POSITIONS[(i * 2 + phase) % 8];
+                let end = POSITIONS[(i * 2 + phase + 1) % 8];
+
+                fn interpolate(start: f32, end: f32, value: f32) -> f32 {
+                    start + ((end - start) * value)
+                }
+
+                let x = interpolate(start.0, end.0, progress);
+                let y = interpolate(start.1, end.1, progress);
+
+                points[i] = graphene::Vec2::new(x, y);
+            }
+
+            points
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct GradientBg(ObjectSubclass<imp::GradientBg>)
+        @extends gtk::Widget, adw::Bin;
+}
+
+impl GradientBg {
+    pub fn new() -> Self {
+        glib::Object::new()
+    }
+
+    pub fn set_pattern(&self, pattern: Option<gdk::Texture>) {
+        self.imp().pattern.replace(pattern);
+    }
+
+    pub fn set_theme_colors(&self, colors: Vec<graphene::Vec3>) {
+        let imp = self.imp();
+
+        imp.colors.replace(colors);
+
+        imp.gradient_texture.take();
+        self.queue_draw();
+    }
+
+    pub fn animate(&self) {
+        let animation = self.imp().animation.get().unwrap();
+
+        let val = animation.value();
+        if val == 0.0 || val == 1.0 {
+            animation.play()
+        }
+    }
+
+    fn ensure_shader(&self) {
+        let imp = self.imp();
+        if imp.shader.borrow().is_none() {
+            let renderer = self.native().unwrap().renderer().unwrap();
+
+            let shader = gsk::GLShader::from_bytes(&GRADIENT_SHADER.into());
+            match shader.compile(&renderer) {
+                Err(e) => {
+                    if !e.matches(gio::IOErrorEnum::NotSupported) {
+                        log::error!("can't compile shader for gradient background {e}");
+                    }
+                    self.add_css_class("fallback");
+                }
+                Ok(_) => {
+                    imp.shader.replace(Some(shader));
+                }
+            }
+        };
+    }
+}
+
+impl Default for GradientBg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn hard_coded_theme_colors(dark: bool) -> Vec<graphene::Vec3> {
+    let colors = if dark {
+        vec![0xd6932e, 0xbc40db, 0x4280d7, 0x614ed5]
+    } else {
+        vec![0x94dae9, 0x9aeddb, 0x94c3f6, 0xac96f7]
+    };
+
+    let colors = colors
+        .into_iter()
+        .map(|int_color| {
+            let r = (int_color >> 16) & 0xFF;
+            let g = (int_color >> 8) & 0xFF;
+            let b = int_color & 0xFF;
+
+            graphene::Vec3::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+        })
+        .collect();
+
+    colors
+}

--- a/origami/src/gradient_bg/mod.rs
+++ b/origami/src/gradient_bg/mod.rs
@@ -25,7 +25,7 @@ mod imp {
         pub(super) phase: Cell<u32>,
 
         pub(super) dark: Cell<bool>,
-        pub(super) colors: RefCell<Vec<graphene::Vec3>>,
+        pub(super) colors: RefCell<Vec<software_gradient::Color>>,
     }
 
     #[glib::object_subclass]
@@ -127,11 +127,8 @@ mod imp {
                 // but I think that 32x32 is better
                 let (width, height) = (32, 32);
 
-                let raw_texture = software_gradient::generate_gradient(
-                    software_gradient::Size { width, height },
-                    colors,
-                    &positions,
-                );
+                let raw_texture =
+                    software_gradient::generate_gradient(width, height, colors, &positions);
 
                 let texture = gdk::MemoryTexture::new(
                     width as i32,
@@ -222,8 +219,14 @@ impl GradientBg {
         self.imp().dark.set(dark);
     }
 
-    pub fn set_theme_colors(&self, colors: Vec<graphene::Vec3>) {
+    // Takes int colors as from theme returned by tdlib
+    pub fn set_theme_colors(&self, colors: &[i32]) {
         let imp = self.imp();
+
+        let colors = colors
+            .iter()
+            .map(|&int| software_gradient::Color::from_int_rgb(int))
+            .collect();
 
         imp.colors.replace(colors);
 

--- a/origami/src/gradient_bg/mod.rs
+++ b/origami/src/gradient_bg/mod.rs
@@ -1,3 +1,5 @@
+mod software_gradient;
+
 use std::cell::Cell;
 use std::cell::OnceCell;
 use std::cell::RefCell;
@@ -6,59 +8,16 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::clone;
 use gtk::gdk;
-use gtk::gio;
 use gtk::glib;
 use gtk::graphene;
-use gtk::gsk;
-
-const GRADIENT_SHADER: &[u8] = r#"
-// That shader was taken from Telegram for android source
-// https://github.com/DrKLO/Telegram/commit/2112affb2e4941334f8fbc3944385806b3c4e3d6#diff-dfdd1e8c4691747fd30199b7a2f5041a126b23e1450b29afe441eb0ebed01c68
-
-precision highp float;
-
-uniform vec3 color1;
-uniform vec3 color2;
-uniform vec3 color3;
-uniform vec3 color4;
-uniform vec2 p1;
-uniform vec2 p2;
-uniform vec2 p3;
-uniform vec2 p4;
-
-void mainImage(out vec4 fragColor,
-               in vec2 fragCoord,
-               in vec2 resolution,
-               in vec2 uv) {
-    uv.y = 1.0 - uv.y;
-
-    float dp1 = distance(uv, p1);
-    float dp2 = distance(uv, p2);
-    float dp3 = distance(uv, p3);
-    float dp4 = distance(uv, p4);
-    float minD = min(dp1, min(dp2, min(dp3, dp4)));
-    float p = 5.0;
-    dp1 = pow(1.0 - (dp1 - minD), p);
-    dp2 = pow(1.0 - (dp2 - minD), p);
-    dp3 = pow(1.0 - (dp3 - minD), p);
-    dp4 = pow(1.0 - (dp4 - minD), p);
-    float sumDp = dp1 + dp2 + dp3 + dp4;
-
-    vec3 color = (color1 * dp1 + color2 * dp2 + color3 * dp3 + color4 * dp4) / sumDp;
-    fragColor = vec4(color, 1.0);
-}
-"#
-.as_bytes();
 
 mod imp {
     use super::*;
 
     #[derive(Default)]
     pub struct GradientBg {
-        pub(super) gradient_texture: RefCell<Option<gdk::Texture>>,
-        pub(super) last_size: Cell<(f32, f32)>,
+        pub(super) gradient_texture: RefCell<Option<gdk::MemoryTexture>>,
 
-        pub(super) shader: RefCell<Option<gsk::GLShader>>,
         pub(super) pattern: RefCell<Option<gdk::Texture>>,
 
         pub(super) animation: OnceCell<adw::Animation>,
@@ -66,7 +25,6 @@ mod imp {
         pub(super) phase: Cell<u32>,
 
         pub(super) dark: Cell<bool>,
-
         pub(super) colors: RefCell<Vec<graphene::Vec3>>,
     }
 
@@ -84,12 +42,6 @@ mod imp {
             let obj = self.obj();
 
             let style_manager = adw::StyleManager::default();
-            obj.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()));
-
-            style_manager.connect_dark_notify(clone!(@weak obj => move |style_manager| {
-                obj.imp().dark.set(style_manager.is_dark());
-                obj.set_theme_colors(hard_coded_theme_colors(style_manager.is_dark()))
-            }));
 
             if style_manager.is_high_contrast() {
                 obj.add_css_class("fallback");
@@ -98,8 +50,6 @@ mod imp {
             style_manager.connect_high_contrast_notify(clone!(@weak obj => move |style_manager| {
                 if style_manager.is_high_contrast() {
                     obj.add_css_class("fallback");
-                } else if obj.imp().shader.borrow().is_some() {
-                    obj.remove_css_class("fallback");
                 }
             }));
 
@@ -131,11 +81,6 @@ mod imp {
     }
 
     impl WidgetImpl for GradientBg {
-        fn realize(&self) {
-            self.parent_realize();
-            self.obj().ensure_shader();
-        }
-
         fn snapshot(&self, snapshot: &gtk::Snapshot) {
             let widget = self.obj();
 
@@ -156,9 +101,7 @@ mod imp {
 
             let bounds = graphene::Rect::new(0.0, 0.0, width, height);
 
-            let size_changed = self.last_size.replace((width, height)) != (width, height);
-
-            self.snapshot_gradient(snapshot, &bounds, size_changed);
+            self.snapshot_gradient(snapshot, &bounds);
 
             self.snapshot_pattern(snapshot, &bounds);
         }
@@ -167,26 +110,45 @@ mod imp {
     impl BinImpl for GradientBg {}
 
     impl GradientBg {
-        fn snapshot_gradient(
-            &self,
-            snapshot: &gtk::Snapshot,
-            bounds: &graphene::Rect,
-            size_changed: bool,
-        ) {
-            if self.progress.get() == 0.0 {
-                let texture = match self.gradient_texture.take() {
-                    Some(texture) if !size_changed => texture,
-                    _ => {
-                        let renderer = self.obj().native().unwrap().renderer().unwrap();
-                        renderer.render_texture(self.gradient_shader_node(bounds), Some(bounds))
-                    }
-                };
+        fn snapshot_gradient(&self, snapshot: &gtk::Snapshot, bounds: &graphene::Rect) {
+            let progress = self.progress.get();
+            let phase = self.phase.get() as usize;
 
-                snapshot.append_texture(&texture, bounds);
-                self.gradient_texture.replace(Some(texture));
+            let cached_texture = (*self.gradient_texture.borrow()).clone();
+
+            let texture = if let Some(texture) = cached_texture {
+                texture
             } else {
-                snapshot.append_node(self.gradient_shader_node(bounds));
-            }
+                let colors = &*self.colors.borrow();
+
+                let positions = Self::calculate_positions(progress, phase);
+
+                // Even with 4x4 the upscaled result looks good,
+                // but I think that 32x32 is better
+                let (width, height) = (32, 32);
+
+                let raw_texture = software_gradient::generate_gradient(
+                    software_gradient::Size { width, height },
+                    colors,
+                    &positions,
+                );
+
+                let texture = gdk::MemoryTexture::new(
+                    width as i32,
+                    height as i32,
+                    gdk::MemoryFormat::B8g8r8a8,
+                    &glib::Bytes::from_owned(raw_texture),
+                    4 * width as usize,
+                );
+
+                if progress == 0.0 {
+                    self.gradient_texture.replace(Some(texture.clone()));
+                }
+
+                texture
+            };
+
+            snapshot.append_texture(&texture, &bounds);
         }
 
         fn snapshot_pattern(&self, snapshot: &gtk::Snapshot, bounds: &graphene::Rect) {
@@ -226,65 +188,18 @@ mod imp {
             }
         }
 
-        fn gradient_shader_node(&self, bounds: &graphene::Rect) -> gsk::GLShaderNode {
-            let Some(gradient_shader) = &*self.shader.borrow() else {
-                unreachable!()
-            };
+        fn calculate_positions(progress: f32, phase: usize) -> Vec<software_gradient::Point> {
+            let mut current = software_gradient::gather_positions(phase);
+            let next = software_gradient::gather_positions(phase + 1);
 
-            let args_builder = gsk::ShaderArgsBuilder::new(gradient_shader, None);
-
-            let progress = self.progress.get();
-            let phase = self.phase.get() as usize;
-
-            let colors = self.colors.borrow();
-
-            let &[c1, c2, c3, c4] = &colors[..] else {
-                unimplemented!("Unexpected color count");
-            };
-
-            args_builder.set_vec3(0, &c1);
-            args_builder.set_vec3(1, &c2);
-            args_builder.set_vec3(2, &c3);
-            args_builder.set_vec3(3, &c4);
-
-            let [p1, p2, p3, p4] = Self::calculate_positions(progress, phase);
-            args_builder.set_vec2(4, &p1);
-            args_builder.set_vec2(5, &p2);
-            args_builder.set_vec2(6, &p3);
-            args_builder.set_vec2(7, &p4);
-
-            gsk::GLShaderNode::new(gradient_shader, bounds, &args_builder.to_args(), &[])
-        }
-
-        fn calculate_positions(progress: f32, phase: usize) -> [graphene::Vec2; 4] {
-            static POSITIONS: [(f32, f32); 8] = [
-                (0.80, 0.10),
-                (0.60, 0.20),
-                (0.35, 0.25),
-                (0.25, 0.60),
-                (0.20, 0.90),
-                (0.40, 0.80),
-                (0.65, 0.75),
-                (0.75, 0.40),
-            ];
-
-            let mut points = [graphene::Vec2::new(0.0, 0.0); 4];
-
-            for i in 0..4 {
-                let start = POSITIONS[(i * 2 + phase) % 8];
-                let end = POSITIONS[(i * 2 + phase + 1) % 8];
-
-                fn interpolate(start: f32, end: f32, value: f32) -> f32 {
-                    start + ((end - start) * value)
-                }
-
-                let x = interpolate(start.0, end.0, progress);
-                let y = interpolate(start.1, end.1, progress);
-
-                points[i] = graphene::Vec2::new(x, y);
+            if progress > 0.0 {
+                current
+                    .iter_mut()
+                    .zip(next)
+                    .for_each(|(current, next)| *current = current.interpolate(next, progress))
             }
 
-            points
+            current
         }
     }
 }
@@ -301,6 +216,10 @@ impl GradientBg {
 
     pub fn set_pattern(&self, pattern: Option<gdk::Texture>) {
         self.imp().pattern.replace(pattern);
+    }
+
+    pub fn set_dark(&self, dark: bool) {
+        self.imp().dark.set(dark);
     }
 
     pub fn set_theme_colors(&self, colors: Vec<graphene::Vec3>) {
@@ -320,51 +239,10 @@ impl GradientBg {
             animation.play()
         }
     }
-
-    fn ensure_shader(&self) {
-        let imp = self.imp();
-        if imp.shader.borrow().is_none() {
-            let renderer = self.native().unwrap().renderer().unwrap();
-
-            let shader = gsk::GLShader::from_bytes(&GRADIENT_SHADER.into());
-            match shader.compile(&renderer) {
-                Err(e) => {
-                    if !e.matches(gio::IOErrorEnum::NotSupported) {
-                        log::error!("can't compile shader for gradient background {e}");
-                    }
-                    self.add_css_class("fallback");
-                }
-                Ok(_) => {
-                    imp.shader.replace(Some(shader));
-                }
-            }
-        };
-    }
 }
 
 impl Default for GradientBg {
     fn default() -> Self {
         Self::new()
     }
-}
-
-fn hard_coded_theme_colors(dark: bool) -> Vec<graphene::Vec3> {
-    let colors = if dark {
-        vec![0xd6932e, 0xbc40db, 0x4280d7, 0x614ed5]
-    } else {
-        vec![0x94dae9, 0x9aeddb, 0x94c3f6, 0xac96f7]
-    };
-
-    let colors = colors
-        .into_iter()
-        .map(|int_color| {
-            let r = (int_color >> 16) & 0xFF;
-            let g = (int_color >> 8) & 0xFF;
-            let b = int_color & 0xFF;
-
-            graphene::Vec3::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
-        })
-        .collect();
-
-    colors
 }

--- a/origami/src/gradient_bg/software_gradient.rs
+++ b/origami/src/gradient_bg/software_gradient.rs
@@ -1,23 +1,35 @@
 // Based on Mikhail Filimonov's code from
 // https://github.com/overtake/TelegramSwift/blob/master/packages/TGUIKit/Sources/SoftwareGradientBackground.swift
 
-pub type Color = gtk::graphene::Vec3;
+pub(super) struct Color {
+    r: f32,
+    g: f32,
+    b: f32,
+}
 
-#[derive(Debug, Clone, Copy)]
-pub struct Size {
-    pub width: u32,
-    pub height: u32,
+impl Color {
+    pub(super) fn new(r: f32, g: f32, b: f32) -> Self {
+        Self { r, g, b }
+    }
+
+    pub(super) fn from_int_rgb(rgb: i32) -> Self {
+        let r = (rgb >> 16) & 0xFF;
+        let g = (rgb >> 8) & 0xFF;
+        let b = rgb & 0xFF;
+
+        Self::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Point {
+pub(super) struct Point {
     pub x: f32,
     pub y: f32,
 }
 
 impl Point {
     #[doc(alias = "interpolatePoints")]
-    pub fn interpolate(self, other: Self, factor: f32) -> Self {
+    pub(super) fn interpolate(self, other: Self, factor: f32) -> Self {
         Self {
             x: self.x * (1.0 - factor) + other.x * factor,
             y: self.y * (1.0 - factor) + other.y * factor,
@@ -43,7 +55,7 @@ static BASE_POSITIONS: &[Point] = &[
 /// ```
 /// so I combined them and it's only possible to change the offset.
 #[doc(alias = "gatherPositions")]
-pub fn gather_positions(offset: usize) -> Vec<Point> {
+pub(super) fn gather_positions(offset: usize) -> Vec<Point> {
     BASE_POSITIONS
         .iter()
         .cycle()
@@ -56,8 +68,9 @@ pub fn gather_positions(offset: usize) -> Vec<Point> {
 
 /// Returns buffer for a texture with BGRA8 format.
 #[doc(alias = "generateGradient")]
-pub fn generate_gradient(
-    Size { width, height }: Size,
+pub(super) fn generate_gradient(
+    width: u32,
+    height: u32,
     colors: &[Color],
     positions: &[Point],
 ) -> Box<[u8]> {
@@ -102,9 +115,9 @@ pub fn generate_gradient(
                 distance = distance * distance * distance;
                 distance_sum += distance;
 
-                r += distance * color.x();
-                g += distance * color.y();
-                b += distance * color.z();
+                r += distance * color.r;
+                g += distance * color.g;
+                b += distance * color.b;
             }
 
             pixel[0] = (b / distance_sum * 255.0) as u8;

--- a/origami/src/gradient_bg/software_gradient.rs
+++ b/origami/src/gradient_bg/software_gradient.rs
@@ -1,0 +1,117 @@
+// Based on Mikhail Filimonov's code from
+// https://github.com/overtake/TelegramSwift/blob/master/packages/TGUIKit/Sources/SoftwareGradientBackground.swift
+
+pub type Color = gtk::graphene::Vec3;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Size {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Point {
+    #[doc(alias = "interpolatePoints")]
+    pub fn interpolate(self, other: Self, factor: f32) -> Self {
+        Self {
+            x: self.x * (1.0 - factor) + other.x * factor,
+            y: self.y * (1.0 - factor) + other.y * factor,
+        }
+    }
+}
+
+static BASE_POSITIONS: &[Point] = &[
+    Point { x: 0.80, y: 0.10 },
+    Point { x: 0.60, y: 0.20 },
+    Point { x: 0.35, y: 0.25 },
+    Point { x: 0.25, y: 0.60 },
+    Point { x: 0.20, y: 0.90 },
+    Point { x: 0.40, y: 0.80 },
+    Point { x: 0.65, y: 0.75 },
+    Point { x: 0.75, y: 0.40 },
+];
+
+/// In the TelegramSwift code
+/// `gatherPositions` `shiftArray` and `basePositions` were always used in combination like that:
+/// ```ignore
+/// gatherPositions(shiftArray(array: AnimatedGradientBackgroundView.basePositions, offset: 0))
+/// ```
+/// so I combined them and it's only possible to change the offset.
+#[doc(alias = "gatherPositions")]
+pub fn gather_positions(offset: usize) -> Vec<Point> {
+    BASE_POSITIONS
+        .iter()
+        .cycle()
+        .skip(offset)
+        .step_by(2)
+        .take(BASE_POSITIONS.len() / 2)
+        .copied()
+        .collect()
+}
+
+/// Returns buffer for a texture with BGRA8 format.
+#[doc(alias = "generateGradient")]
+pub fn generate_gradient(
+    Size { width, height }: Size,
+    colors: &[Color],
+    positions: &[Point],
+) -> Box<[u8]> {
+    let bytes_per_row = 4 * width as usize;
+    let mut image_bytes = vec![0u8; bytes_per_row * height as usize].into_boxed_slice();
+
+    for (y, row) in image_bytes.chunks_exact_mut(bytes_per_row).enumerate() {
+        let direct_pixel_y = y as f32 / height as f32;
+        let center_distance_y = direct_pixel_y - 0.5;
+        let center_distance_y2 = center_distance_y * center_distance_y;
+
+        for (x, pixel) in row.chunks_exact_mut(4).enumerate() {
+            let direct_pixel_x = x as f32 / height as f32;
+            let center_distance_x = direct_pixel_x - 0.5;
+
+            let center_distance =
+                (center_distance_x * center_distance_x + center_distance_y2).sqrt();
+
+            let swirl_factor = 0.35 * center_distance;
+            let theta = swirl_factor * swirl_factor * 0.8 * 8.0;
+
+            // Note: sin_cos takes noticable amount of time.
+            // It's possible to get better performance
+            let (sin_theta, cos_theta) = theta.sin_cos();
+
+            let pixel_x = (0.5 + center_distance_x * cos_theta - center_distance_y * sin_theta)
+                .clamp(0.0, 1.0);
+
+            let pixel_y = (0.5 + center_distance_x * sin_theta + center_distance_y * cos_theta)
+                .clamp(0.0, 1.0);
+
+            let mut distance_sum = 0.0;
+            let (mut r, mut g, mut b) = (0.0, 0.0, 0.0);
+
+            for (color, pos) in colors.iter().zip(positions.iter()) {
+                let distance_x = pixel_x - pos.x;
+                let distance_y = pixel_y - pos.y;
+
+                let mut distance =
+                    (0.92 - (distance_x * distance_x + distance_y * distance_y).sqrt()).max(0.0);
+
+                distance = distance * distance * distance;
+                distance_sum += distance;
+
+                r += distance * color.x();
+                g += distance * color.y();
+                b += distance * color.z();
+            }
+
+            pixel[0] = (b / distance_sum * 255.0) as u8;
+            pixel[1] = (g / distance_sum * 255.0) as u8;
+            pixel[2] = (r / distance_sum * 255.0) as u8;
+            pixel[3] = 255;
+        }
+    }
+    image_bytes
+}

--- a/origami/src/lib.rs
+++ b/origami/src/lib.rs
@@ -1,10 +1,13 @@
 //! [Paper Plane](https://github.com/paper-plane-developers/paper-plane) related set of gtk widgets that can be usable outside of it.
 
+mod gradient_bg;
 mod loading_indicator;
 mod shimmer_effect;
 mod spoiler_overlay;
 
 use gtk::prelude::StaticType;
+
+pub use gradient_bg::GradientBg;
 pub use loading_indicator::LoadingIndicator;
 pub use shimmer_effect::ShimmerEffect;
 pub use spoiler_overlay::SpoilerOverlay;
@@ -13,6 +16,7 @@ pub use spoiler_overlay::SpoilerOverlay;
 ///
 /// Expected to be called in the main function
 pub fn init() {
+    GradientBg::static_type();
     LoadingIndicator::static_type();
     ShimmerEffect::static_type();
     SpoilerOverlay::static_type();


### PR DESCRIPTION
That's gradient background from Paper Plane, but with software rendering intstead.

The method to set the theme should exist on the Paper Plane side because I don't want to pull tdlib and want GradientBg to be compiled with optimizations (so in a separate of Paper Plane crate).